### PR TITLE
Add configurable delay during playlist processing

### DIFF
--- a/zotify/config.py
+++ b/zotify/config.py
@@ -10,6 +10,8 @@ SKIP_EXISTING = 'SKIP_EXISTING'
 SKIP_PREVIOUSLY_DOWNLOADED = 'SKIP_PREVIOUSLY_DOWNLOADED'
 DOWNLOAD_FORMAT = 'DOWNLOAD_FORMAT'
 BULK_WAIT_TIME = 'BULK_WAIT_TIME'
+PL_BULK_WAIT_TIME = 'PL_BULK_WAIT_TIME'
+PL_BATCH = 'PL_BATCH'
 OVERRIDE_AUTO_WAIT = 'OVERRIDE_AUTO_WAIT'
 CHUNK_SIZE = 'CHUNK_SIZE'
 SPLIT_ALBUM_DISCS = 'SPLIT_ALBUM_DISCS'
@@ -56,6 +58,8 @@ CONFIG_VALUES = {
     SKIP_PREVIOUSLY_DOWNLOADED: { 'default': 'False', 'type': bool, 'arg': '--skip-previously-downloaded' },
     RETRY_ATTEMPTS:             { 'default': '1',     'type': int,  'arg': '--retry-attempts'             },
     BULK_WAIT_TIME:             { 'default': '1',     'type': int,  'arg': '--bulk-wait-time'             },
+    PL_BULK_WAIT_TIME:          { 'default': '1',     'type': int,  'arg': '--pl-bulk-wait-time'          },
+    PL_BATCH:                   { 'default': '0',     'type': int,  'arg': '--pl-batch'                   },
     OVERRIDE_AUTO_WAIT:         { 'default': 'False', 'type': bool, 'arg': '--override-auto-wait'         },
     CHUNK_SIZE:                 { 'default': '20000', 'type': int,  'arg': '--chunk-size'                 },
     DOWNLOAD_REAL_TIME:         { 'default': 'False', 'type': bool, 'arg': '--download-real-time'         },
@@ -199,6 +203,14 @@ class Config:
     @classmethod
     def get_bulk_wait_time(cls) -> int:
         return cls.get(BULK_WAIT_TIME)
+
+    @classmethod
+    def get_pl_bulk_wait_time(cls) -> int:
+        return cls.get(PL_BULK_WAIT_TIME)
+
+    @classmethod
+    def get_pl_batch(cls) -> int:
+        return cls.get(PL_BATCH)
 
     @classmethod
     def get_language(cls) -> str:

--- a/zotify/playlist.py
+++ b/zotify/playlist.py
@@ -1,8 +1,9 @@
 from zotify.const import ITEMS, ID, TRACK, NAME
-from zotify.termoutput import Printer
+from zotify.termoutput import Printer, PrintChannel
 from zotify.track import download_track
 from zotify.utils import split_input
 from zotify.zotify import Zotify
+import time
 
 MY_PLAYLISTS_URL = 'https://api.spotify.com/v1/me/playlists'
 PLAYLISTS_URL = 'https://api.spotify.com/v1/playlists'
@@ -52,10 +53,20 @@ def download_playlist(playlist):
     playlist_songs = [song for song in get_playlist_songs(playlist[ID]) if song[TRACK] is not None and song[TRACK][ID]]
     p_bar = Printer.progress(playlist_songs, unit='song', total=len(playlist_songs), unit_scale=True)
     enum = 1
+    plimit = 1
+    pl_batch = Zotify.CONFIG.get_pl_batch()
     for song in p_bar:
         download_track('extplaylist', song[TRACK][ID], extra_keys={'playlist': playlist[NAME], 'playlist_num': str(enum).zfill(2)}, disable_progressbar=True)
         p_bar.set_description(song[TRACK][NAME])
         enum += 1
+        if pl_batch > 0:
+            plimit += 1
+            if plimit >= pl_batch:
+                if Zotify.CONFIG.get_pl_bulk_wait_time():
+                    pl_wait_time = Zotify.CONFIG.get_pl_bulk_wait_time()
+                    Printer.print(PrintChannel.PROGRESS_INFO, f'Pausing after {pl_batch} song queries in playlist. Waiting {pl_wait_time} seconds.')
+                    time.sleep(pl_wait_time)
+                plimit = 1
 
 
 def download_from_user_playlist():

--- a/zotify/playlist.py
+++ b/zotify/playlist.py
@@ -53,7 +53,7 @@ def download_playlist(playlist):
     playlist_songs = [song for song in get_playlist_songs(playlist[ID]) if song[TRACK] is not None and song[TRACK][ID]]
     p_bar = Printer.progress(playlist_songs, unit='song', total=len(playlist_songs), unit_scale=True)
     enum = 1
-    plimit = 1
+    plimit = -1
     pl_batch = Zotify.CONFIG.get_pl_batch()
     for song in p_bar:
         download_track('extplaylist', song[TRACK][ID], extra_keys={'playlist': playlist[NAME], 'playlist_num': str(enum).zfill(2)}, disable_progressbar=True)
@@ -66,7 +66,7 @@ def download_playlist(playlist):
                     pl_wait_time = Zotify.CONFIG.get_pl_bulk_wait_time()
                     Printer.print(PrintChannel.PROGRESS_INFO, f'Pausing after {pl_batch} song queries in playlist. Waiting {pl_wait_time} seconds.')
                     time.sleep(pl_wait_time)
-                plimit = 1
+                plimit = -1
 
 
 def download_from_user_playlist():


### PR DESCRIPTION
Just a little something I whipped up as I hit a 422 song playlist.  Yes this can result in stacking delays when it hits the batch limit as both the song delay as well as the playlist batch delay could fire but afaik there isn't a way for it to know if a song was downloaded during that batch process.  

Helps to avoid API errors during long playlists especially if you are reprocessing one you downloaded previously.  This is off by default.

Adds options PL_BULK_WAIT_TIME and PL_BATCH config options.
PL_BULK_WAIT_TIME defaults to 1 (just like BULK_WAIT_TIME)
PL_BATCH defaults to 0 which is it's off or disable state.  Set to any value greater than 0 to enable batching the playlist download.