### PR TITLE
Fix disc splitting error

### DIFF
--- a/zotify/config.py
+++ b/zotify/config.py
@@ -279,28 +279,33 @@ class Config:
             return v
         if mode == 'playlist':
             if cls.get_split_album_discs():
-                split = PurePath(OUTPUT_DEFAULT_PLAYLIST).parent
-                return PurePath(split).joinpath('Disc {disc_number}').joinpath(split)
+                path = PurePath(OUTPUT_DEFAULT_PLAYLIST).parent
+                file = PurePath(OUTPUT_DEFAULT_PLAYLIST).name
+                return str(PurePath(path).joinpath('Disc {disc_number}').joinpath(file))
             return OUTPUT_DEFAULT_PLAYLIST
         if mode == 'extplaylist':
             if cls.get_split_album_discs():
-                split = PurePath(OUTPUT_DEFAULT_PLAYLIST_EXT).parent
-                return PurePath(split).joinpath('Disc {disc_number}').joinpath(split)
+                path = PurePath(OUTPUT_DEFAULT_PLAYLIST_EXT).parent
+                file = PurePath(OUTPUT_DEFAULT_PLAYLIST_EXT).name
+                return str(PurePath(path).joinpath('Disc {disc_number}').joinpath(file))
             return OUTPUT_DEFAULT_PLAYLIST_EXT
         if mode == 'liked':
             if cls.get_split_album_discs():
-                split = PurePath(OUTPUT_DEFAULT_LIKED_SONGS).parent
-                return PurePath(split).joinpath('Disc {disc_number}').joinpath(split)
+                path = PurePath(OUTPUT_DEFAULT_LIKED_SONGS).parent
+                file = PurePath(OUTPUT_DEFAULT_LIKED_SONGS).name
+                return str(PurePath(path).joinpath('Disc {disc_number}').joinpath(file))
             return OUTPUT_DEFAULT_LIKED_SONGS
         if mode == 'single':
             if cls.get_split_album_discs():
-                split = PurePath(OUTPUT_DEFAULT_SINGLE).parent
-                return PurePath(split).joinpath('Disc {disc_number}').joinpath(split)
+                path = PurePath(OUTPUT_DEFAULT_SINGLE).parent
+                file = PurePath(OUTPUT_DEFAULT_SINGLE).name
+                return str(PurePath(path).joinpath('Disc {disc_number}').joinpath(file))
             return OUTPUT_DEFAULT_SINGLE
         if mode == 'album':
             if cls.get_split_album_discs():
-                split = PurePath(OUTPUT_DEFAULT_ALBUM).parent
-                return PurePath(split).joinpath('Disc {disc_number}').joinpath(split)
+                path = PurePath(OUTPUT_DEFAULT_ALBUM).parent
+                file = PurePath(OUTPUT_DEFAULT_ALBUM).name
+                return str(PurePath(path).joinpath('Disc {disc_number}').joinpath(file))
             return OUTPUT_DEFAULT_ALBUM
         raise ValueError()
 


### PR DESCRIPTION
Might not be the most elegant way but didn't see another option.  Original code add the parent twice to the output template and failed to re-introduce the filename template portion that was stripped during the split.  This adds that back and corrects the second joinpath() so it references that rather than the split.  split renamed to path to indicate what it contains.

This also converts the PurePath object to a string via another route.