### PR TITLE
fix cover-art issue

### DIFF
--- a/zotify/utils.py
+++ b/zotify/utils.py
@@ -146,23 +146,19 @@ def conv_artist_format(artists) -> str:
 
 
 def set_music_thumbnail(filename, image_url) -> None:
-    """ Downloads cover artwork, saves it as a JPEG, and embeds it into the music file's metadata """
+    """ Directly embeds cover artwork into the music file without saving to disk """
+    try:
+        # Download image data directly from URL
+        img_data = requests.get(image_url).content
 
-    # Determine the new image filename with .jpg extension
-    image_filename = Path(filename).parent.joinpath('cover.jpg')
+        # Load the music file and set artwork from the image data
+        tags = music_tag.load_file(filename)
+        tags['artwork'] = img_data  # Embed image data directly
+        tags.save()
 
-    # Check if the image file already exists
-    if not image_filename.exists():
-        img = requests.get(image_url).content
-        with open(image_filename, 'wb') as img_file:
-            img_file.write(img)
-        print(f"Image saved as {image_filename}")
-
-    # Add the image to the music file's metadata
-    tags = music_tag.load_file(filename)
-    with open(image_filename, 'rb') as img_file:
-        tags['artwork'] = img_file.read()
-    tags.save()
+        print(f"Embedded artwork into {filename}")
+    except Exception as e:
+        print(f"Error setting artwork for {filename}: {str(e)}")
 
 
 def regex_input_for_urls(search_input) -> Tuple[str, str, str, str, str, str]:


### PR DESCRIPTION
# Fix Cover Art Overwrite Issue by Embedding Artwork Directly

## Summary
This change ensures each track's cover art is unique by embedding artwork directly into the audio file instead of relying on a shared `cover.jpg` file. This resolves the issue where subsequent tracks in the same directory reused the first track's cover art.

---

## Problem
When downloading multiple tracks in the same directory:
1. The first track creates a `cover.jpg` file.
2. Subsequent tracks reuse this file instead of downloading their own artwork.
3. All tracks in the directory display the first track's cover art.

---

## Solution
- **Removed reliance on disk storage**: Instead of saving `cover.jpg`, artwork is fetched directly from the URL and embedded into the audio file's metadata.
- **Direct embedding**: The cover art is stored inside each music file (e.g., MP3/OGG), ensuring track-specific accuracy.

---

## Benefits
- **No more `cover.jpg` conflicts**: Each track's artwork is stored internally.
- **Track-specific accuracy**: Every file now has its own correct cover art.
- **Simplified workflow**: Removes disk I/O for temporary files.

---

## Testing
1. Download multiple tracks from different albums into the same folder.
2. Verify:
   - Each track shows its own cover art in media players.
   - No leftover `cover.jpg` files (optional cleanup).

---

## Checklist
- [x] Tested with mixed-album downloads
- [x] Verified artwork displays correctly in players
- [x] Checked error handling (e.g., invalid URLs)